### PR TITLE
RTK Queryを使用して、apiからデータ取得するように

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "packageManager": "yarn@3.2.3",
   "scripts": {
-    "dev": "dev:next && dev:scss",
+    "dev": "yarn dev:next && yarn dev:scss",
     "dev:next": "next dev",
     "dev:scss": "typed-scss-modules src --watch",
     "build:next": "next build && next export",
@@ -16,11 +16,13 @@
     "typegen:scss": "typed-scss-modules src"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.0",
     "highcharts": "^10.3.1",
     "next": "^13.0.4",
     "normalize.css": "^8.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.0.5",
     "sass": "^1.56.1"
   },
   "devDependencies": {

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,9 @@
+'use client'
+
 import 'normalize.css'
 import '@/styles/global.scss'
+import { Provider } from 'react-redux'
+import { store } from '@/rtk/store'
 
 export default function RootLayout({
   children
@@ -9,7 +13,9 @@ export default function RootLayout({
   return (
     <html lang={'ja'}>
       <head />
-      <body>{children}</body>
+      <body>
+        <Provider store={store}>{children}</Provider>
+      </body>
     </html>
   )
 }

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 export default function Home() {
   return <h1>Hello, Nex\!</h1>
 }

--- a/app/src/rtk/api/baseApi.ts
+++ b/app/src/rtk/api/baseApi.ts
@@ -1,0 +1,15 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+
+export const baseApi = createApi({
+  reducerPath: 'baseApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'https://opendata.resas-portal.go.jp',
+    prepareHeaders: (headers) => {
+      if (process.env.NEXT_PUBLIC_RESAS_API_KEY) {
+        headers.set('X-API-KEY', process.env.NEXT_PUBLIC_RESAS_API_KEY)
+      }
+      return headers
+    }
+  }),
+  endpoints: () => ({})
+})

--- a/app/src/rtk/api/index.ts
+++ b/app/src/rtk/api/index.ts
@@ -1,0 +1,7 @@
+// 都道府県一覧
+export { useGetPrefecturesQuery } from '@/rtk/api/prefectures/prefectures'
+export type { PrefecturesType } from '@/rtk/api/prefectures/prefectures'
+
+// 人口構成（年単位）
+export { useGetPopulationQuery } from '@/rtk/api/populations/populations'
+export type { PopulationType } from '@/rtk/api/populations/populations'

--- a/app/src/rtk/api/populations/populations.ts
+++ b/app/src/rtk/api/populations/populations.ts
@@ -1,0 +1,34 @@
+import { baseApi } from '@/rtk/api/baseApi'
+
+export type PopulationType = {
+  message: null
+  result: {
+    boundaryYear: number
+    data: {
+      label: string
+      data: {
+        year: number
+        value: number
+        rate?: number
+      }[]
+    }[]
+  }[]
+}
+
+type PopulationParamsType = {
+  prefCode: number
+  cityCode?: number
+}
+
+const populationsApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getPopulation: builder.query<PopulationType, PopulationParamsType>({
+      query: ({ prefCode, cityCode = '-' }) => ({
+        url: `/api/v1/population/composition/perYear?cityCode=${cityCode}&prefCode=${prefCode}`
+      })
+    })
+  }),
+  overrideExisting: false
+})
+
+export const { useGetPopulationQuery } = populationsApi

--- a/app/src/rtk/api/prefectures/prefectures.ts
+++ b/app/src/rtk/api/prefectures/prefectures.ts
@@ -1,0 +1,22 @@
+import { baseApi } from '@/rtk/api/baseApi'
+
+export type PrefecturesType = {
+  message: null
+  result: {
+    prefCode: number
+    prefName: string
+  }[]
+}
+
+const prefecturesApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getPrefectures: builder.query<PrefecturesType, void>({
+      query: () => ({
+        url: `/api/v1/prefectures`
+      })
+    })
+  }),
+  overrideExisting: false
+})
+
+export const { useGetPrefecturesQuery } = prefecturesApi

--- a/app/src/rtk/store.ts
+++ b/app/src/rtk/store.ts
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { baseApi } from '@/rtk/api/baseApi'
+
+export const store = configureStore({
+  reducer: {
+    [baseApi.reducerPath]: baseApi.reducer
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(baseApi.middleware)
+})

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -15,7 +15,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.18.9":
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.9.2":
   version: 7.20.1
   resolution: "@babel/runtime@npm:7.20.1"
   dependencies:
@@ -281,6 +281,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@reduxjs/toolkit@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@reduxjs/toolkit@npm:1.9.0"
+  dependencies:
+    immer: ^9.0.16
+    redux: ^4.2.0
+    redux-thunk: ^2.4.2
+    reselect: ^4.1.7
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18
+    react-redux: ^7.2.1 || ^8.0.2
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: 34452bc5d41ae401f6673ae418afface339a3cf5990dfac2f784295cebcecabf83aade228671fc03d4c450b752334822d9504164862039be3945527bc94981bc
+  languageName: node
+  linkType: hard
+
 "@rushstack/eslint-patch@npm:^1.1.3":
   version: 1.2.0
   resolution: "@rushstack/eslint-patch@npm:1.2.0"
@@ -317,6 +337,16 @@ __metadata:
   dependencies:
     "@types/ms": "*"
   checksum: 0a7b89d8ed72526858f0b61c6fd81f477853e8c4415bb97f48b1b5545248d2ae389931680b94b393b993a7cfe893537a200647d93defe6d87159b96812305adc
+  languageName: node
+  linkType: hard
+
+"@types/hoist-non-react-statics@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@types/hoist-non-react-statics@npm:3.3.1"
+  dependencies:
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+  checksum: 2c0778570d9a01d05afabc781b32163f28409bb98f7245c38d5eaf082416fdb73034003f5825eb5e21313044e8d2d9e1f3fe2831e345d3d1b1d20bcd12270719
   languageName: node
   linkType: hard
 
@@ -402,6 +432,13 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: c31bf04eb9620829dc3c91bced74ac934ad039d20d20893fb5acac0f08769cbd4eef3bf7502a0289c7be59c3e9cfa456147b4e88bff47dd1b9efb4995ba5d5a3
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@types/use-sync-external-store@npm:0.0.3"
+  checksum: 161ddb8eec5dbe7279ac971531217e9af6b99f7783213566d2b502e2e2378ea19cf5e5ea4595039d730aa79d3d35c6567d48599f69773a02ffcff1776ec2a44e
   languageName: node
   linkType: hard
 
@@ -668,6 +705,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:."
   dependencies:
+    "@reduxjs/toolkit": ^1.9.0
     "@types/node": ^18.11.9
     "@types/react": ^18.0.25
     "@types/react-dom": ^18.0.9
@@ -683,6 +721,7 @@ __metadata:
     prettier: ^2.7.1
     react: ^18.2.0
     react-dom: ^18.2.0
+    react-redux: ^8.0.5
     sass: ^1.56.1
     typed-scss-modules: ^7.0.1
     typescript: ^4.9.3
@@ -2480,6 +2519,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: ^16.7.0
+  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.0":
   version: 4.1.0
   resolution: "http-cache-semantics@npm:4.1.0"
@@ -2553,6 +2601,13 @@ __metadata:
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
+  languageName: node
+  linkType: hard
+
+"immer@npm:^9.0.16":
+  version: 9.0.16
+  resolution: "immer@npm:9.0.16"
+  checksum: e9a5ca65c929b329da7a3b7beccf7984271cda7bdd47b2cab619eac3277dcd56598c211b55cc340786b6eff0c06652ac018808d9fd744443f06882364dece6bc
   languageName: node
   linkType: hard
 
@@ -3873,10 +3928,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^18.0.0":
+  version: 18.2.0
+  resolution: "react-is@npm:18.2.0"
+  checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
+  languageName: node
+  linkType: hard
+
+"react-redux@npm:^8.0.5":
+  version: 8.0.5
+  resolution: "react-redux@npm:8.0.5"
+  dependencies:
+    "@babel/runtime": ^7.12.1
+    "@types/hoist-non-react-statics": ^3.3.1
+    "@types/use-sync-external-store": ^0.0.3
+    hoist-non-react-statics: ^3.3.2
+    react-is: ^18.0.0
+    use-sync-external-store: ^1.0.0
+  peerDependencies:
+    "@types/react": ^16.8 || ^17.0 || ^18.0
+    "@types/react-dom": ^16.8 || ^17.0 || ^18.0
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+    react-native: ">=0.59"
+    redux: ^4
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+    redux:
+      optional: true
+  checksum: a108f4f7ead6ac005e656d46051474a2bbdb31ede481bbbb3d8d779c1a35e1940b8655577cc5021313411864d305f67fc719aa48d6e5ed8288cf9cbe8b7042e4
   languageName: node
   linkType: hard
 
@@ -3909,6 +4003,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redux-thunk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "redux-thunk@npm:2.4.2"
+  peerDependencies:
+    redux: ^4
+  checksum: c7f757f6c383b8ec26152c113e20087818d18ed3edf438aaad43539e9a6b77b427ade755c9595c4a163b6ad3063adf3497e5fe6a36c68884eb1f1cfb6f049a5c
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "redux@npm:4.2.0"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+  checksum: 75f3955c89b3f18edf5411e5fb482aa2e4f41a416183e8802a6bf6472c4fc3d47675b8b321d147f8af8e0f616436ac507bf5a25f1c4d6180e797b549c7db2c1d
+  languageName: node
+  linkType: hard
+
 "regenerator-runtime@npm:^0.13.10":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
@@ -3938,6 +4050,13 @@ __metadata:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: fb47e70bf0001fdeabdc0429d431863e9475e7e43ea5f94ad86503d918423c1543361cc5166d713eaa7029dd7a3d34775af04764bebff99ef413111a5af18c80
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "reselect@npm:4.1.7"
+  checksum: 738d8e2b8f0dca154ad29de6a209c9fbca2d70ae6788fd85df87f2c74b95a65bbf2d16d43a9e2faff39de34d17a29d706ba08a6b2ee5660c09589edbd19af7e1
   languageName: node
   linkType: hard
 
@@ -4684,7 +4803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:1.2.0":
+"use-sync-external-store@npm:1.2.0, use-sync-external-store@npm:^1.0.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:


### PR DESCRIPTION
## 💫 関連Issues
close #2 

## 💪🏻 変更したこと
- RTK Queryを利用し、RESAS APIの該当エンドポイントからデータを取得するようにした
  - [都道府県一覧](https://opendata.resas-portal.go.jp/docs/api/v1/prefectures.html)
  - [人口構成](https://opendata.resas-portal.go.jp/docs/api/v1/population/composition/perYear.html)

## 👀 確認項目
- `app/src/rtk/api/index.ts`からインポートできるhooksを使って、データを取得できるか
  - `const { data } = use~~~~({ パラメータ })` でdataを取得できます

## ✅ 自主確認リスト
- [ ] The Nu Html Checkerでエラーがでていないか
  - [ローカルに実行環境を構築](https://a11y-guidelines.freee.co.jp/explanations/nu-html-checker.html#id79)