### PR TITLE
#7 チェックされたら人口構成を取得するように

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
   const { data: prefecturesData, isLoading: isPrefecturesLoading } =
     useGetPrefecturesQuery()
   const { prefs, checkPrefsHandler } = useCheckPrefs()
-  const { data: populationsData, isLoading: isPopulationsLoading } =
+  const { isLoading: isPopulationsLoading } =
     useGetPopulationsQuery(prefs)
 
   const isLoading = isPrefecturesLoading || isPopulationsLoading

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,11 +1,16 @@
 'use client'
 
 import { CheckBox } from '@/components/CheckBox'
+import { useCheckPrefs } from '@/hooks/useCheckPrefs'
 import { useGetPrefecturesQuery } from '@/rtk/api'
 
 export default function Home() {
   const { data: prefecturesData, isLoading: isPrefecturesLoading } =
     useGetPrefecturesQuery()
+  const { prefs, checkPrefsHandler } = useCheckPrefs()
+
+  // Todo: 流し込むときにprefsを使う
+  console.log(prefs)
 
   const isLoading = isPrefecturesLoading
   return (
@@ -19,6 +24,7 @@ export default function Home() {
               key={data.prefCode}
               name={data.prefName}
               value={data.prefCode}
+              onChange={checkPrefsHandler}
             />
           ))}
         </>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -8,8 +8,7 @@ export default function Home() {
   const { data: prefecturesData, isLoading: isPrefecturesLoading } =
     useGetPrefecturesQuery()
   const { prefs, checkPrefsHandler } = useCheckPrefs()
-  const { isLoading: isPopulationsLoading } =
-    useGetPopulationsQuery(prefs)
+  const { isLoading: isPopulationsLoading } = useGetPopulationsQuery(prefs)
 
   const isLoading = isPrefecturesLoading || isPopulationsLoading
   return (

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -2,17 +2,16 @@
 
 import { CheckBox } from '@/components/CheckBox'
 import { useCheckPrefs } from '@/hooks/useCheckPrefs'
-import { useGetPrefecturesQuery } from '@/rtk/api'
+import { useGetPopulationsQuery, useGetPrefecturesQuery } from '@/rtk/api'
 
 export default function Home() {
   const { data: prefecturesData, isLoading: isPrefecturesLoading } =
     useGetPrefecturesQuery()
   const { prefs, checkPrefsHandler } = useCheckPrefs()
+  const { data: populationsData, isLoading: isPopulationsLoading } =
+    useGetPopulationsQuery(prefs)
 
-  // Todo: 流し込むときにprefsを使う
-  console.log(prefs)
-
-  const isLoading = isPrefecturesLoading
+  const isLoading = isPrefecturesLoading || isPopulationsLoading
   return (
     <>
       {isLoading || !prefecturesData ? (

--- a/app/src/components/CheckBox.tsx
+++ b/app/src/components/CheckBox.tsx
@@ -1,12 +1,21 @@
+import React from 'react'
+
 type CheckBoxProps = {
   name: string
   value: number
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
 
-export const CheckBox = ({ name, value }: CheckBoxProps) => {
+export const CheckBox = ({ name, value, onChange }: CheckBoxProps) => {
   return (
     <div>
-      <input type={'checkbox'} id={name} value={value} />
+      <input
+        type={'checkbox'}
+        id={name}
+        value={value}
+        name={name}
+        onChange={(e) => onChange(e)}
+      />
       <label htmlFor={name}>{name}</label>
     </div>
   )

--- a/app/src/hooks/useCheckPrefs.ts
+++ b/app/src/hooks/useCheckPrefs.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+import { PrefType } from '@/rtk/api'
+
+export const useCheckPrefs = () => {
+  const [prefs, setPrefs] = useState<PrefType[]>([])
+
+  const checkPrefsHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const isChecked = e.target.checked
+    const prefCode = parseInt(e.target.value)
+    const prefName = e.target.name
+
+    if (isChecked) {
+      setPrefs((prefs) => [...prefs, { prefCode, prefName }])
+    } else {
+      setPrefs((prefs) => prefs.filter((item) => prefCode !== item.prefCode))
+    }
+  }
+
+  return { prefs, checkPrefsHandler }
+}

--- a/app/src/rtk/api/baseApi.ts
+++ b/app/src/rtk/api/baseApi.ts
@@ -3,7 +3,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 export const baseApi = createApi({
   reducerPath: 'baseApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: 'https://opendata.resas-portal.go.jp',
+    baseUrl: 'https://opendata.resas-portal.go.jp/api/v1',
     prepareHeaders: (headers) => {
       if (process.env.NEXT_PUBLIC_RESAS_API_KEY) {
         headers.set('X-API-KEY', process.env.NEXT_PUBLIC_RESAS_API_KEY)

--- a/app/src/rtk/api/index.ts
+++ b/app/src/rtk/api/index.ts
@@ -3,5 +3,5 @@ export { useGetPrefecturesQuery } from '@/rtk/api/prefectures/prefectures'
 export type { PrefsType, PrefType } from '@/rtk/api/prefectures/prefectures'
 
 // 人口構成（年単位）
-export { useGetPopulationQuery } from '@/rtk/api/populations/populations'
+export { useGetPopulationsQuery } from '@/rtk/api/populations/populations'
 export type { PopulationType } from '@/rtk/api/populations/populations'

--- a/app/src/rtk/api/prefectures/prefectures.ts
+++ b/app/src/rtk/api/prefectures/prefectures.ts
@@ -14,7 +14,7 @@ const prefecturesApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getPrefectures: builder.query<PrefsType, void>({
       query: () => ({
-        url: `/api/v1/prefectures`
+        url: `/prefectures`
       })
     })
   }),


### PR DESCRIPTION
## 💫 関連Issues
close #7 

## 💪🏻 変更したこと
- 複数パラメータに対応するようにgetPopulations api修正
- チェックボックスのイベントハンドラ追加
- apiのエントリーポイント修正

## 👀 確認項目
- `useGetPopulationsQuery`で、チェックされている都道府県の人口構成のデータが取得されること

## ✅ 自主確認リスト
- [x] The Nu Html Checkerでエラーがでていないか
  - [ローカルに実行環境を構築](https://a11y-guidelines.freee.co.jp/explanations/nu-html-checker.html#id79)